### PR TITLE
add hook unbind to removeEventListener on mouseup

### DIFF
--- a/dist/v-selection.js
+++ b/dist/v-selection.js
@@ -7,7 +7,7 @@
 		exports["selection"] = factory();
 	else
 		root["selection"] = factory();
-})(this, function() {
+})(typeof self !== 'undefined' ? self : this, function() {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -84,8 +84,12 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 var vueSelection = {
-  bind: function bind(el, binding, vnode) {
-    document.body.addEventListener('mouseup', handleMouseUp);
+  unbind: function unbind(_, binding) {
+    document.body.removeEventListener('mouseup', binding.def.handler);
+  },
+  bind: function bind(el, binding) {
+    binding.def.handler = handleMouseUp;
+    document.body.addEventListener('mouseup', binding.def.handler);
 
     /**
      * handle mouseup event on body

--- a/selection.js
+++ b/selection.js
@@ -1,6 +1,10 @@
 const vueSelection = {
-  bind(el, binding, vnode) {
-    document.body.addEventListener('mouseup', handleMouseUp)
+  unbind(_,binding){
+    document.body.removeEventListener('mouseup', binding.def.handler)
+  },
+  bind(el, binding) {
+    binding.def.handler = handleMouseUp
+    document.body.addEventListener('mouseup', binding.def.handler)
     
     /**
      * handle mouseup event on body


### PR DESCRIPTION
This change will fix this issue ( #2 ).
Add hook unbind to remove the event listener before the component will be removed from the dom.